### PR TITLE
fix: format warnings and add standart c99

### DIFF
--- a/makefile
+++ b/makefile
@@ -1,6 +1,6 @@
 TARGET = course-project
 
-FLAGS = -Wall
+FLAGS = -Wall -std=c99
 
 RELEASE_PREF = release
 SRC_PREF = sources

--- a/sources/files_api.c
+++ b/sources/files_api.c
@@ -1,3 +1,5 @@
+#define __USE_MINGW_ANSI_STDIO 1
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>


### PR DESCRIPTION
1) исправлен предупреждение с нераспознаванием формата в считывании строки
2) добавлен флаг стандарта C99